### PR TITLE
fix most pylint errors in database directory

### DIFF
--- a/backend/adumbra/database/__init__.py
+++ b/backend/adumbra/database/__init__.py
@@ -1,20 +1,19 @@
 import json
 import typing as t
 
-from mongoengine import DynamicDocument, QuerySet, connect, fields
+from mongoengine import DynamicDocument, QuerySet, connect
 from mongoengine.base import BaseField
-from mongoengine.queryset.manager import queryset_manager
 
 from adumbra.config import Config
-from adumbra.database.annotations import *
-from adumbra.database.categories import *
-from adumbra.database.datasets import *
-from adumbra.database.events import *
-from adumbra.database.exports import *
-from adumbra.database.images import *
-from adumbra.database.lisence import *
-from adumbra.database.tasks import *
-from adumbra.database.users import *
+from adumbra.database.annotations import AnnotationModel
+from adumbra.database.categories import CategoryModel
+from adumbra.database.datasets import DatasetModel
+from adumbra.database.events import Event, SessionEvent
+from adumbra.database.exports import ExportModel
+from adumbra.database.images import ImageModel
+from adumbra.database.lisence import LicenseModel
+from adumbra.database.tasks import TaskModel
+from adumbra.database.users import UserModel
 
 FieldBase_T = t.TypeVar("FieldBase_T", bound=type[BaseField])
 
@@ -53,7 +52,7 @@ def fix_ids(q):
 
 def create_from_json(json_file):
 
-    with open(json_file) as file:
+    with open(json_file, encoding="utf-8") as file:
 
         data_json = json.load(file)
         for category in data_json.get("categories", []):

--- a/backend/adumbra/database/annotations.py
+++ b/backend/adumbra/database/annotations.py
@@ -5,14 +5,15 @@ import cv2
 import imantics as im
 import numpy as np
 from flask_login import current_user
-from mongoengine import DynamicDocument, fields
+from mongoengine import fields
 
 from adumbra.database.categories import CategoryModel
 from adumbra.database.datasets import DatasetModel
 from adumbra.database.events import Event
+from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 
-class AnnotationModel(DynamicDocument):
+class AnnotationModel(ShimmedDynamicDocument):
 
     COCO_PROPERTIES = [
         "id",
@@ -57,7 +58,6 @@ class AnnotationModel(DynamicDocument):
     events = fields.EmbeddedDocumentListField(Event)
 
     def __init__(self, image_id=None, **data):
-
         from adumbra.database.images import ImageModel
 
         if image_id is not None:
@@ -71,7 +71,7 @@ class AnnotationModel(DynamicDocument):
 
         super(AnnotationModel, self).__init__(**data)
 
-    def save(self, copy=False, *args, **kwargs):
+    def save(self, *args, copy=False, **kwargs):
 
         if self.dataset_id and not copy:
             dataset = DatasetModel.objects(id=self.dataset_id).first()

--- a/backend/adumbra/database/categories.py
+++ b/backend/adumbra/database/categories.py
@@ -1,9 +1,11 @@
 import imantics as im
 from flask_login import current_user
-from mongoengine import DynamicDocument, fields
+from mongoengine import fields
+
+from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 
-class CategoryModel(DynamicDocument):
+class CategoryModel(ShimmedDynamicDocument):
 
     COCO_PROPERTIES = [
         "id",

--- a/backend/adumbra/database/datasets.py
+++ b/backend/adumbra/database/datasets.py
@@ -51,7 +51,7 @@ class DatasetModel(ShimmedDynamicDocument):
         from adumbra.workers.tasks import import_annotations
 
         task = TaskModel(
-            name="Import COCO format into {}".format(self.name),
+            name=f"Import COCO format into {self.name}",
             dataset_id=self.id,
             group="Annotation Import",
         )

--- a/backend/adumbra/database/datasets.py
+++ b/backend/adumbra/database/datasets.py
@@ -1,33 +1,34 @@
 import os
 
 from flask_login import current_user
-from mongoengine import *
+from mongoengine import fields
 
 from adumbra.config import Config
+from adumbra.database.mongo_shim import ShimmedDynamicDocument
 from adumbra.database.tasks import TaskModel
 
 
-class DatasetModel(DynamicDocument):
+class DatasetModel(ShimmedDynamicDocument):
 
-    id = SequenceField(primary_key=True)
-    name = StringField(required=True, unique=True)
-    directory = StringField()
-    thumbnails = StringField()
-    categories = ListField(default=[])
+    id = fields.SequenceField(primary_key=True)
+    name = fields.StringField(required=True, unique=True)
+    directory = fields.StringField()
+    thumbnails = fields.StringField()
+    categories = fields.ListField(default=[])
 
-    owner = StringField(required=True)
-    users = ListField(default=[])
+    owner = fields.StringField(required=True)
+    users = fields.ListField(default=[])
 
-    annotate_url = StringField(default="")
+    annotate_url = fields.StringField(default="")
 
-    default_annotation_metadata = DictField(default={})
+    default_annotation_metadata = fields.DictField(default={})
 
-    deleted = BooleanField(default=False)
-    deleted_date = DateTimeField()
+    deleted = fields.BooleanField(default=False)
+    deleted_date = fields.DateTimeField()
 
     def save(self, *args, **kwargs):
 
-        directory = os.path.join(Config.DATASET_DIRECTORY, self.name + "/")
+        directory = os.path.join(Config.DATASET_DIRECTORY, str(self.name) + "/")
         os.makedirs(directory, mode=0o777, exist_ok=True)
 
         self.directory = directory

--- a/backend/adumbra/database/events.py
+++ b/backend/adumbra/database/events.py
@@ -1,29 +1,30 @@
 import datetime
 import time
 
-from mongoengine import *
+from mongoengine import EmbeddedDocument, fields
 
 
 class Event(EmbeddedDocument):
 
-    name = StringField()
-    created_at = DateTimeField()
+    name = fields.StringField()
+    created_at = fields.DateTimeField()
 
     meta = {"allow_inheritance": True}
 
     def now(self, event):
+        del event
         self.created_at = datetime.datetime.now()
 
 
 class SessionEvent(Event):
 
-    user = StringField(required=True)
-    milliseconds = IntField(default=0, min_value=0)
-    tools_used = ListField(default=[])
+    user = fields.StringField(required=True)
+    milliseconds = fields.IntField(default=0, min_value=0)
+    tools_used = fields.ListField(default=[])
 
     @classmethod
-    def create(self, start, user, end=None, tools=[]):
-
+    def create(cls, start, user, end=None, tools: list[str] | None = None):
+        del tools
         if end is None:
             end = time.time()
 

--- a/backend/adumbra/database/images.py
+++ b/backend/adumbra/database/images.py
@@ -1,19 +1,18 @@
 import os
-import uuid
 
 import imantics as im
-import requests
-from mongoengine import DynamicDocument, fields
+from mongoengine import fields
 from PIL import Image, ImageFile
 
 from adumbra.database.annotations import AnnotationModel
 from adumbra.database.datasets import DatasetModel
 from adumbra.database.events import Event, SessionEvent
+from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
-class ImageModel(DynamicDocument):
+class ImageModel(ShimmedDynamicDocument):
 
     COCO_PROPERTIES = [
         "id",
@@ -151,6 +150,7 @@ class ImageModel(DynamicDocument):
 
             self.update(is_modified=False)
             return pil_image
+        return None
 
     def open_thumbnail(self):
         """
@@ -236,6 +236,7 @@ class ImageModel(DynamicDocument):
 
     # TODO: Fix why using the functions throws an error
     def permissions(self, user):
+        del user
         return {"delete": True, "download": True}
 
     def add_event(self, e):

--- a/backend/adumbra/database/mongo_shim.py
+++ b/backend/adumbra/database/mongo_shim.py
@@ -1,0 +1,5 @@
+from mongoengine import DynamicDocument, QuerySet
+
+
+class ShimmedDynamicDocument(DynamicDocument):
+    objects: QuerySet

--- a/backend/adumbra/database/tasks.py
+++ b/backend/adumbra/database/tasks.py
@@ -1,10 +1,12 @@
 import datetime
 import typing as t
 
-from mongoengine import DynamicDocument, fields
+from mongoengine import fields
+
+from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 
-class TaskModel(DynamicDocument):
+class TaskModel(ShimmedDynamicDocument):
     id = fields.SequenceField(primary_key=True)
 
     # Type of task: Importer, Exporter, Scanner, etc.
@@ -71,7 +73,7 @@ class TaskModel(DynamicDocument):
 
     def set_progress(self, percent, socket=None):
 
-        self.update(progress=int(percent), completed=(percent >= 100))
+        self.update(progress=int(percent), completed=percent >= 100)
 
         # Send socket update every 10%
         if self._progress_update < percent or percent >= 100:

--- a/backend/adumbra/database/users.py
+++ b/backend/adumbra/database/users.py
@@ -1,15 +1,16 @@
 import datetime
 
 from flask_login import UserMixin
-from mongoengine import DynamicDocument, Q, fields
+from mongoengine import Q, fields
 
 from adumbra.database.annotations import AnnotationModel
 from adumbra.database.categories import CategoryModel
 from adumbra.database.datasets import DatasetModel
 from adumbra.database.images import ImageModel
+from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 
-class UserModel(DynamicDocument, UserMixin):
+class UserModel(ShimmedDynamicDocument, UserMixin):
 
     password = fields.StringField(required=True)
     username = fields.StringField(max_length=25, required=True, unique=True)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,12 @@ build-backend = "hatchling.build"
 [project]
 name = "adumbra"
 version = "1.0.0"
-authors = [{ name = "@ntjess" }, { name = "@jdrakes" }, { name = "@sixks" }, { name = "@jsbroks" }]
+authors = [
+    { name = "@ntjess" },
+    { name = "@jdrakes" },
+    { name = "@sixks" },
+    { name = "@jsbroks" },
+]
 
 dependencies = [
     "celery",
@@ -62,10 +67,21 @@ disable = [
     "too-few-public-methods",
     "use-implicit-booleaness-not-len",
     "useless-import-alias",
+    # These are specific to legacy code -- consider changing code instead of suppressing
+    # in the future
+    "logging-format-interpolation",
+    "super-with-arguments",
 ]
 max-args = 10
 max-attributes = 10
 max-locals = 20
+generated-member = [
+    "cv2.fillPoly",
+    "cv2.polylines",
+    "cv2.rectangle",
+    "cv2.circle",
+    "cv2.findContours",
+]
 
 [tool.pyright]
 typeCheckingMode = "basic"


### PR DESCRIPTION
Addresses wildcard imports, file encoding, `objects` access, etc. Now, the only errors are from "runtime" imports inside functions, which would take a bit more effort:

```
************* Module adumbra.database.annotations
adumbra/database/annotations.py:61:8: C0415: Import outside toplevel (adumbra.database.images.ImageModel) (import-outside-toplevel)
************* Module adumbra.database.datasets
adumbra/database/datasets.py:40:8: C0415: Import outside toplevel (adumbra.database.users.UserModel) (import-outside-toplevel)
adumbra/database/datasets.py:51:8: C0415: Import outside toplevel (adumbra.workers.tasks.import_annotations) (import-outside-toplevel)
adumbra/database/datasets.py:54:17: C0209: Formatting a regular string which could be an f-string (consider-using-f-string)
adumbra/database/datasets.py:66:8: C0415: Import outside toplevel (adumbra.workers.tasks.export_annotations) (import-outside-toplevel)
adumbra/database/datasets.py:86:8: C0415: Import outside toplevel (adumbra.workers.tasks.scan_dataset) (import-outside-toplevel)
************* Module adumbra.database.users
adumbra/database/users.py:1:0: R0401: Cyclic import (adumbra.database.annotations -> adumbra.database.datasets -> adumbra.database.users) (cyclic-import)
adumbra/database/users.py:1:0: R0401: Cyclic import (adumbra.database.annotations -> adumbra.database.images) (cyclic-import)
adumbra/database/users.py:1:0: R0401: Cyclic import (adumbra.database.datasets -> adumbra.database.users) (cyclic-import)
adumbra/database/users.py:1:0: R0401: Cyclic import (adumbra.database.annotations -> adumbra.database.datasets -> adumbra.database.users -> adumbra.database.images) (cyclic-import)
```