### PR TITLE
`mongodb` forces you to explicitly specify abstract bases.

### DIFF
--- a/backend/adumbra/database/mongo_shim.py
+++ b/backend/adumbra/database/mongo_shim.py
@@ -2,4 +2,7 @@ from mongoengine import DynamicDocument, QuerySet
 
 
 class ShimmedDynamicDocument(DynamicDocument):
+    """Provides type hinting on `objects`, nothing more."""
+
+    meta = {"abstract": True}
     objects: QuerySet


### PR DESCRIPTION
See https://www.tutorialspoint.com/mongoengine/mongoengine_document_inheritance.htm for details