### PR TITLE
Ensure models are available on named `models` mount

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -85,5 +85,6 @@ ENV ZIM="1"
 COPY ./backend/requirements-ia/ /tmp/requirements-ia/
 RUN /tmp/requirements-ia/install_requirements.py
 
+COPY ./models/ /models/
 EXPOSE 6000
 CMD ["gunicorn", "-c", "adumbra/gunicorn_config.py", "adumbra.ia:app", "--bind", "0.0.0.0:6000", "--no-sendfile"]


### PR DESCRIPTION
This way, we don't need to explicitly `docker cp` things after building