### PR TITLE
Use pydantic for config settings.

### DIFF
--- a/backend/adumbra/database/__init__.py
+++ b/backend/adumbra/database/__init__.py
@@ -4,7 +4,7 @@ import typing as t
 from mongoengine import DynamicDocument, QuerySet, connect
 from mongoengine.base import BaseField
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database.annotations import AnnotationModel
 from adumbra.database.categories import CategoryModel
 from adumbra.database.datasets import DatasetModel
@@ -20,7 +20,7 @@ FieldBase_T = t.TypeVar("FieldBase_T", bound=type[BaseField])
 
 def connect_mongo(name, host=None):
     if host is None:
-        host = Config.MONGODB_HOST
+        host = CONFIG.mongodb_host
     connect(name, host=host)
 
 

--- a/backend/adumbra/database/datasets.py
+++ b/backend/adumbra/database/datasets.py
@@ -3,7 +3,7 @@ import os
 from flask_login import current_user
 from mongoengine import fields
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database.mongo_shim import ShimmedDynamicDocument
 from adumbra.database.tasks import TaskModel
 
@@ -28,7 +28,7 @@ class DatasetModel(ShimmedDynamicDocument):
 
     def save(self, *args, **kwargs):
 
-        directory = os.path.join(Config.DATASET_DIRECTORY, str(self.name) + "/")
+        directory = os.path.join(CONFIG.dataset_directory, str(self.name) + "/")
         os.makedirs(directory, mode=0o777, exist_ok=True)
 
         self.directory = directory

--- a/backend/adumbra/gunicorn_config.py
+++ b/backend/adumbra/gunicorn_config.py
@@ -1,17 +1,7 @@
-from adumbra.config import Config
+from adumbra.config import CONFIG
 
-bind = "0.0.0.0:5001"
-backlog = 2048
 
-workers = 1
-worker_class = "eventlet"
-worker_connections = 1000
-timeout = 60
-keepalive = 2
-
-reload = Config.DEBUG
-preload = Config.PRELOAD
-
-errorlog = "-"
-loglevel = Config.LOG_LEVEL
-accesslog = None
+def __getattr__(name):
+    # Allow setting config values where gunicorn expects, but manage them with
+    # pydantic settings
+    return getattr(CONFIG.gunicorn, name)

--- a/backend/adumbra/ia/__init__.py
+++ b/backend/adumbra/ia/__init__.py
@@ -6,7 +6,7 @@ from flask import Flask
 from flask_cors import CORS
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import create_from_json
 from adumbra.ia.api import blueprint as api
 
@@ -22,7 +22,7 @@ def create_app():
 
     flask = Flask(__name__, static_url_path="", static_folder="../dist")
 
-    flask.config.from_object(Config)
+    flask.config.from_object(CONFIG)
 
     CORS(flask)
 
@@ -39,8 +39,8 @@ app.logger.handlers = logger.handlers
 app.logger.setLevel(logger.level)
 
 
-if Config.INITIALIZE_FROM_FILE:
-    create_from_json(Config.INITIALIZE_FROM_FILE)
+if CONFIG.initialize_from_file:
+    create_from_json(CONFIG.initialize_from_file)
 
 
 @app.route("/", defaults={"path": ""})

--- a/backend/adumbra/ia/api/__init__.py
+++ b/backend/adumbra/ia/api/__init__.py
@@ -1,17 +1,16 @@
 from flask import Blueprint
 from flask_restx import Api
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.ia.api.models import api as ns_models
-
 
 # Create /api/ space
 blueprint = Blueprint("api", __name__, url_prefix="/api")
 
 api = Api(
     blueprint,
-    title=Config.NAME,
-    version=Config.VERSION,
+    title=CONFIG.name,
+    version=CONFIG.version,
 )
 
 # Remove default namespace

--- a/backend/adumbra/ia/util/sam2.py
+++ b/backend/adumbra/ia/util/sam2.py
@@ -5,13 +5,13 @@ import numpy as np
 from sam2.build_sam import build_sam2
 from sam2.sam2_image_predictor import SAM2ImagePredictor
 
-from adumbra.config import Config as AnnotatorConfig
+from adumbra.config import CONFIG as AnnotatorConfig
 
 logger = logging.getLogger("gunicorn.error")
 
 MODEL_DIR = "/workspace/models"
-SAM2_MODEL_PATH = AnnotatorConfig.SAM2_MODEL_FILE
-SAM2_MODEL_CONFIG = AnnotatorConfig.SAM2_MODEL_CONFIG
+SAM2_MODEL_PATH = AnnotatorConfig.sam2.default_model_path
+SAM2_MODEL_CONFIG = AnnotatorConfig.sam2.default_model_config
 
 
 class SAM2:
@@ -23,14 +23,14 @@ class SAM2:
 
     def __init__(self):
         logger.info(
-            f"zz info: {SAM2_MODEL_CONFIG}, {SAM2_MODEL_PATH}, {AnnotatorConfig.DEVICE}"
+            f"zz info: {SAM2_MODEL_CONFIG}, {SAM2_MODEL_PATH}, {AnnotatorConfig.ia_device}"
         )
         SAM2_LOADED = os.path.isfile(SAM2_MODEL_PATH)
         if SAM2_LOADED:
             self.sam2_model = build_sam2(
                 SAM2_MODEL_CONFIG,
                 ckpt_path=SAM2_MODEL_PATH,
-                device=AnnotatorConfig.DEVICE,
+                device=AnnotatorConfig.ia_device,
             )
             self.is_loaded = True
             logger.info("SAM2 model is loaded.")

--- a/backend/adumbra/ia/util/zim.py
+++ b/backend/adumbra/ia/util/zim.py
@@ -5,13 +5,13 @@ import numpy as np
 import torch
 from zim_anything import ZimPredictor, zim_model_registry
 
-from adumbra.config import Config as AnnotatorConfig
+from adumbra.config import CONFIG as AnnotatorConfig
 
 logger = logging.getLogger("gunicorn.error")
 
 MODEL_DIR = "/workspace/models"
-ZIM_MODEL_PATH = AnnotatorConfig.ZIM_MODEL_FILE
-ZIM_MODEL_TYPE = AnnotatorConfig.ZIM_MODEL_TYPE
+ZIM_MODEL_PATH = AnnotatorConfig.zim.default_model_path
+ZIM_MODEL_TYPE = AnnotatorConfig.zim.default_model_type
 
 
 class ZIM:
@@ -21,7 +21,7 @@ class ZIM:
     logits: np.ndarray | None = None
 
     def __init__(self):
-        device = AnnotatorConfig.DEVICE
+        device = AnnotatorConfig.ia_device
         logger.info(f"zz info: {ZIM_MODEL_TYPE}, {ZIM_MODEL_PATH}, {device}")
         ZIM_LOADED = os.path.isdir(ZIM_MODEL_PATH)
         if ZIM_LOADED:

--- a/backend/adumbra/webserver/__init__.py
+++ b/backend/adumbra/webserver/__init__.py
@@ -13,7 +13,7 @@ from flask_socketio import SocketIO
 # from werkzeug.contrib.fixers import ProxyFix
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import ImageModel, connect_mongo, create_from_json
 from adumbra.webserver.api import blueprint as api
 from adumbra.webserver.authentication import login_manager
@@ -41,7 +41,7 @@ def create_app():
         static_folder="../dist",
     )
 
-    flask.config.from_object(Config)
+    flask.config.from_object(CONFIG)
 
     CORS(flask)
 
@@ -55,7 +55,7 @@ def create_app():
         flask,
         async_mode="eventlet",
         cors_allowed_origins="*",
-        message_queue=Config.CELERY_BROKER_URL,
+        message_queue=CONFIG.celery.broker_url,
     )
     # Remove all poeple who were annotating when
     # the server shutdown
@@ -72,8 +72,8 @@ app.logger.handlers = logger.handlers
 app.logger.setLevel(logger.level)
 
 
-if Config.INITIALIZE_FROM_FILE:
-    create_from_json(Config.INITIALIZE_FROM_FILE)
+if CONFIG.initialize_from_file:
+    create_from_json(CONFIG.initialize_from_file)
 
 
 @app.route("/assets/<path:filepath>")

--- a/backend/adumbra/webserver/api/__init__.py
+++ b/backend/adumbra/webserver/api/__init__.py
@@ -1,7 +1,7 @@
 from flask import Blueprint
 from flask_restx import Api
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.webserver.api.admin import api as ns_admin
 from adumbra.webserver.api.annotations import api as ns_annotations
 from adumbra.webserver.api.annotator import api as ns_annotator
@@ -21,8 +21,8 @@ blueprint = Blueprint("api", __name__, url_prefix="/api")
 
 api = Api(
     blueprint,
-    title=Config.NAME,
-    version=Config.VERSION,
+    title=CONFIG.name,
+    version=CONFIG.version,
 )
 
 # Remove default namespace

--- a/backend/adumbra/webserver/api/annotator.py
+++ b/backend/adumbra/webserver/api/annotator.py
@@ -4,7 +4,7 @@ from flask import request
 from flask_login import current_user, login_required
 from flask_restx import Namespace, Resource
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import AnnotationModel, CategoryModel, ImageModel, SessionEvent
 from adumbra.webserver.util import coco_util, profile, query_util, thumbnails
 
@@ -174,7 +174,7 @@ class AnnotatorId(Resource):
         nex = images.filter(file_name__gt=image.file_name).order_by("file_name").first()
 
         preferences = {}
-        if not Config.LOGIN_DISABLED:
+        if not CONFIG.login_disabled:
             preferences = current_user.preferences
 
         # Generate data about the image to return to client

--- a/backend/adumbra/webserver/api/info.py
+++ b/backend/adumbra/webserver/api/info.py
@@ -1,6 +1,6 @@
 from flask_restx import Namespace, Resource
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import TaskModel, UserModel
 from adumbra.workers.tasks import long_task
 
@@ -17,10 +17,10 @@ class Info(Resource):
             "author": "Nathan Jessurun, James Drakes, SixK",
             # "demo": "",
             "repo": "https://github.com/TerraVerum/adumbra",
-            "git": {"tag": Config.VERSION},
-            "login_enabled": not Config.LOGIN_DISABLED,
+            "git": {"tag": CONFIG.version},
+            "login_enabled": not CONFIG.login_disabled,
             "total_users": UserModel.objects.count(),
-            "allow_registration": Config.ALLOW_REGISTRATION,
+            "allow_registration": CONFIG.allow_registration,
         }
 
 

--- a/backend/adumbra/webserver/api/users.py
+++ b/backend/adumbra/webserver/api/users.py
@@ -4,7 +4,7 @@ from flask_login import current_user, login_required, login_user, logout_user
 from flask_restx import Namespace, Resource, reqparse
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import UserModel
 from adumbra.webserver.util.query_util import fix_ids
 
@@ -32,7 +32,7 @@ class User(Resource):
     @login_required
     def get(self):
         """Get information of current user"""
-        if Config.LOGIN_DISABLED:
+        if CONFIG.login_disabled:
             return current_user.to_json()
 
         user_json = fix_ids(current_user)
@@ -74,7 +74,7 @@ class UserRegister(Resource):
 
         users = UserModel.objects.count()
 
-        if not Config.ALLOW_REGISTRATION and users != 0:
+        if not CONFIG.allow_registration and users != 0:
             return {
                 "success": False,
                 "message": "Registration of new accounts is disabled.",

--- a/backend/adumbra/webserver/sockets.py
+++ b/backend/adumbra/webserver/sockets.py
@@ -6,7 +6,7 @@ from flask import session
 from flask_login import current_user
 from flask_socketio import SocketIO, disconnect, emit, join_room, leave_room
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import ImageModel, SessionEvent
 
 logger = logging.getLogger("gunicorn.error")
@@ -18,7 +18,7 @@ socketio = SocketIO()
 def authenticated_only(f):
     @functools.wraps(f)
     def wrapped(*args, **kwargs):
-        if current_user.is_authenticated or Config.LOGIN_DISABLED:
+        if current_user.is_authenticated or CONFIG.login_disabled:
             return f(*args, **kwargs)
         else:
             disconnect()

--- a/backend/adumbra/webserver/watcher.py
+++ b/backend/adumbra/webserver/watcher.py
@@ -3,7 +3,7 @@ import re
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import ImageModel
 from adumbra.webserver.util.thumbnails import generate_thumbnail
 
@@ -58,5 +58,5 @@ class ImageFolderHandler(FileSystemEventHandler):
 
 def run_watcher():
     observer = Observer()
-    observer.schedule(ImageFolderHandler(), Config.DATASET_DIRECTORY, recursive=True)
+    observer.schedule(ImageFolderHandler(), CONFIG.dataset_directory, recursive=True)
     observer.start()

--- a/backend/adumbra/workers/__init__.py
+++ b/backend/adumbra/workers/__init__.py
@@ -1,12 +1,12 @@
 from celery import Celery
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 from adumbra.database import connect_mongo
 
 connect_mongo("Celery_Worker")
 
 celery = Celery(
-    Config.NAME, backend=Config.CELERY_RESULT_BACKEND, broker=Config.CELERY_BROKER_URL
+    CONFIG.name, backend=CONFIG.celery.result_backend, broker=CONFIG.celery.broker_url
 )
 celery.autodiscover_tasks(["adumbra.workers.tasks"])
 

--- a/backend/adumbra/workers/socket.py
+++ b/backend/adumbra/workers/socket.py
@@ -1,7 +1,7 @@
 from flask_socketio import SocketIO
 
-from adumbra.config import Config
+from adumbra.config import CONFIG
 
 
 def create_socket():
-    return SocketIO(message_queue=Config.CELERY_BROKER_URL)
+    return SocketIO(message_queue=CONFIG.celery.broker_url)

--- a/compose-extensions/ia-cpu.yml
+++ b/compose-extensions/ia-cpu.yml
@@ -19,7 +19,6 @@ services:
       # Install IA aplications or not
       - SAM2="1"
       - ZIM="1"
-      - SAM2_MODEL_FILE=/models/sam2.1_hiera_base_plus.pt
-      - SAM2_MODEL_CONFIG=configs/sam2.1/sam2.1_hiera_b+.yaml
-      - ZIM_MODEL_FILE=/models/zim/
-      - ZIM_MODEL_TYPE=vit_b
+      - SAM2_DEFAULT_MODEL_PATH=/models/sam2.1_hiera_base_plus.pt
+      - ZIM_DEFAULT_MODEL_PATH=/models/zim/
+      - ZIM_DEFAULT_MODEL_TYPE=vit_b


### PR DESCRIPTION
Uses lowercase inner names to conform to pydantic settings conventions. Allows many benefits compared to home-grown config solution:
- Can fetch environment variables from OS, .env files, or set during runtime (and as a result, plays nice with [secret rotation](https://docs.docker.com/engine/swarm/secrets/#how-docker-manages-secrets))
- Allows nesting config settings models:
  * Improved organization as more settings are added
  * Makes it clearer which settings are consumed by which backend objects