### PR TITLE
Simplify ia build process across multiple device backends

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         entry: black
         language: system
         types: [python]
-        args: [--check, --config-root=backend/pyproject.toml]
+        args: [--check, --config=backend/pyproject.toml]
       - id: unimport
         name: unimport
         entry: unimport

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -65,21 +65,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pytorch torchvision pytorch-cuda=12.4 cudnn
 
 FROM adumbra-python AS adumbra-ia-cpu
-RUN conda install -c pytorch -y \
-    pytorch torchvision \
-    && conda clean --all --yes
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/opt/conda/pkgs \
+    conda install -c pytorch -y pytorch torchvision
 
 FROM adumbra-ia-${DEVICE} AS adumbra-ia
 # ARG goes away each stage, so we need to re-define it here
 ARG DEVICE=cpu
-# ------
-# https://github.com/facebookresearch/sam2/blob/main/INSTALL.md
-# indicates we need to explicitly request they don't build a cuda extension.
-# Zim depends on SAM1, which has a similar env-configured cuda builder listening for
-# FORCE_CUDA
-RUN CUDA_AVAILABLE=$([ "${DEVICE}" = "cuda" ] && echo 1 || echo 0) && \
-    echo "SAM2_BUILD_CUDA=$CUDA_AVAILABLE" >> /etc/environment \
-    && echo "FORCE_CUDA=$CUDA_AVAILABLE" >> /etc/environment
+ENV DEVICE=${DEVICE}
 
 # Reads environment variables and installs sam/zim/etc as needed with minimal
 # dependencies

--- a/backend/adumbra/ia/api/__init__.py
+++ b/backend/adumbra/ia/api/__init__.py
@@ -7,11 +7,7 @@ from adumbra.ia.api.models import api as ns_models
 # Create /api/ space
 blueprint = Blueprint("api", __name__, url_prefix="/api")
 
-api = Api(
-    blueprint,
-    title=CONFIG.name,
-    version=CONFIG.version,
-)
+api = Api(blueprint, title=CONFIG.name, version=CONFIG.version)
 
 # Remove default namespace
 api.namespaces.pop(0)

--- a/backend/adumbra/ia/api/models.py
+++ b/backend/adumbra/ia/api/models.py
@@ -20,12 +20,6 @@ image_upload.add_argument(
     "image", location="files", type=FileStorage, required=True, help="Image"
 )
 
-sam_args = reqparse.RequestParser()
-sam_args.add_argument("data", type=str, required=True)
-sam_args.add_argument(
-    "image", location="files", type=FileStorage, required=True, help="Image"
-)
-
 sam2_args = reqparse.RequestParser()
 sam2_args.add_argument("data", type=str, required=True)
 sam2_args.add_argument(

--- a/backend/adumbra/ia/util/sam2.py
+++ b/backend/adumbra/ia/util/sam2.py
@@ -5,13 +5,9 @@ import numpy as np
 from sam2.build_sam import build_sam2
 from sam2.sam2_image_predictor import SAM2ImagePredictor
 
-from adumbra.config import CONFIG as AnnotatorConfig
+from adumbra.config import CONFIG
 
 logger = logging.getLogger("gunicorn.error")
-
-MODEL_DIR = "/workspace/models"
-SAM2_MODEL_PATH = AnnotatorConfig.sam2.default_model_path
-SAM2_MODEL_CONFIG = AnnotatorConfig.sam2.default_model_config
 
 
 class SAM2:
@@ -22,18 +18,18 @@ class SAM2:
     predictor: SAM2ImagePredictor | None = None
 
     def __init__(self):
-        logger.info(
-            f"zz info: {SAM2_MODEL_CONFIG}, {SAM2_MODEL_PATH}, {AnnotatorConfig.ia_device}"
-        )
-        SAM2_LOADED = os.path.isfile(SAM2_MODEL_PATH)
+        ia_settings = CONFIG.ia
+        config = ia_settings.sam2.default_model_config
+        model_path = ia_settings.sam2.default_model_path
+        device = ia_settings.get_best_device()
+        logger.info(f"SAM2 info: {config}, {model_path}, {device}")
+        SAM2_LOADED = os.path.isfile(model_path)
         if SAM2_LOADED:
             self.sam2_model = build_sam2(
-                SAM2_MODEL_CONFIG or None,
-                ckpt_path=SAM2_MODEL_PATH,
-                device=AnnotatorConfig.ia_device,
+                config or None, ckpt_path=model_path, device=device
             )
             self.is_loaded = True
-            logger.info("SAM2 model is loaded.")
+            logger.info(f"SAM2 model is loaded on device. {device}")
         else:
             logger.warning("SAM2 model is disabled.")
 

--- a/backend/requirements-ia/install_requirements.py
+++ b/backend/requirements-ia/install_requirements.py
@@ -5,17 +5,38 @@ import subprocess
 import sys
 from pathlib import Path
 
-env_requirements_map = {
-    "SAM2": "sam2.in",
-    "ZIM": "zim.in",
-}
+
+class BuildSettings:
+    def __init__(self):
+        self.device = os.getenv("DEVICE", "cpu")
+
+    def is_gpu_like(self):
+        return self.device.lower().startswith("cuda")
+
+    def is_cpu_like(self):
+        return not self.is_gpu_like()
+
+
+BUILD_SETTINGS = BuildSettings()
 # Match quote, allow everything but that quote inside, then match the quote again
 SINGLE_QUOTE_REGEX = r"'[^']*?'"
 DOUBLE_QUOTE_REGEX = r'"[^"]*?"'
 IF_PARSE_REGEX = re.compile(
     rf"--if[= ](?P<if_statement>{SINGLE_QUOTE_REGEX}|{DOUBLE_QUOTE_REGEX})"
 )
-DEFAULT_SCOPE = {"os": os, "sys": sys}
+DEFAULT_SCOPE = {"build_env": BUILD_SETTINGS}
+
+requirements_files = ["requirements.in"]
+
+
+def get_cuda_env_patch():
+    """
+    https://github.com/facebookresearch/sam2/blob/main/INSTALL.md indicates we need to
+    explicitly request they don't build a cuda extension. Zim depends on SAM1, which has
+    a similar env-configured cuda builder listening for FORCE_CUDA
+    """
+    attempt_cuda = "1" if BUILD_SETTINGS.is_gpu_like() else "0"
+    return {"FORCE_CUDA": attempt_cuda, "SAM2_BUILD_CUDA": attempt_cuda}
 
 
 def eval_if_statement(line: str, scope: dict | None = None):
@@ -40,8 +61,7 @@ def normalize_requirement(req: str) -> str:
 def install_requirements():
     here = Path(__file__).resolve().parent
     reqs_text = [
-        here.joinpath(req).read_text(encoding="utf-8")
-        for (env, req) in env_requirements_map.items()
+        here.joinpath(req).read_text(encoding="utf-8") for req in requirements_files
     ]
     all_reqs = "\n".join(reqs_text)
 
@@ -58,10 +78,13 @@ def install_requirements():
         else:
             allow_sub_deps.append(normalized)
     cmd_prefix = [sys.executable, "-m", "pip", "install"]
+    env_patch = get_cuda_env_patch()
     if no_sub_deps:
-        subprocess.run([*cmd_prefix, "--no-deps", *no_sub_deps], check=True)
+        subprocess.run(
+            [*cmd_prefix, "--no-deps", *no_sub_deps], check=True, env=env_patch
+        )
     if allow_sub_deps:
-        subprocess.run([*cmd_prefix, *allow_sub_deps], check=True)
+        subprocess.run([*cmd_prefix, *allow_sub_deps], check=True, env=env_patch)
 
 
 if __name__ == "__main__":

--- a/backend/requirements-ia/requirements.in
+++ b/backend/requirements-ia/requirements.in
@@ -1,0 +1,15 @@
+# ------------------------------
+# ZIM
+# ------------------------------
+# "if" and --no-deps syntax only supported in the `install_requirements` parsing script
+zim_anything  # --no-deps
+easydict
+setuptools
+onnx
+onnxruntime-gpu  # --if="build_env.is_gpu_like()"
+onnxruntime  # --if="build_env.is_cpu_like()"
+
+# ------------------------------
+# SAM2
+# ------------------------------
+sam-2@git+https://github.com/facebookresearch/sam2@2b90b9f5ceec907a1c18123530e92e794ad901a4

--- a/backend/requirements-ia/sam2.in
+++ b/backend/requirements-ia/sam2.in
@@ -1,1 +1,0 @@
-sam-2@git+https://github.com/facebookresearch/sam2@2b90b9f5ceec907a1c18123530e92e794ad901a4

--- a/backend/requirements-ia/zim.in
+++ b/backend/requirements-ia/zim.in
@@ -1,7 +1,0 @@
-# "if" syntax is only supported in the `install_requirements` parsing script
-zim_anything  # --no-deps
-easydict
-setuptools
-onnx
-onnxruntime-gpu  # --if="os.getenv('DEVICE', 'cpu') == 'cuda'"
-onnxruntime  # --if="os.getenv('DEVICE', 'cpu') == 'cpu'"

--- a/compose-extensions/ia-cpu.yml
+++ b/compose-extensions/ia-cpu.yml
@@ -16,9 +16,8 @@ services:
       - FILE_WATCHER=true
       - FLASK__SECRET_KEY=RandomSecretKeyHere
       - FLASK_APP=ia
-      - DEVICE=cpu
       # Install IA aplications or not
-      - SAM2__DEFAULT_MODEL_PATH=/models/sam2.1_hiera_base_plus.pt
-      - SAM2__DEFAULT_MODEL_CONFIG=configs/sam2.1/sam2.1_hiera_b+.yaml
-      - ZIM__DEFAULT_MODEL_PATH=/models/zim/
-      - ZIM__DEFAULT_MODEL_TYPE=vit_b
+      - IA__SAM2__DEFAULT_MODEL_PATH=/models/sam2.1_hiera_base_plus.pt
+      - IA__SAM2__DEFAULT_MODEL_CONFIG=configs/sam2.1/sam2.1_hiera_b+.yaml
+      - IA__ZIM__DEFAULT_MODEL_PATH=/models/zim/
+      - IA__ZIM__DEFAULT_MODEL_TYPE=vit_b

--- a/compose-extensions/ia-gpu.yml
+++ b/compose-extensions/ia-gpu.yml
@@ -17,5 +17,3 @@ services:
               - driver: nvidia
                 device_ids: ["0"]
                 capabilities: ["gpu"]
-    environment:
-      - DEVICE=cuda


### PR DESCRIPTION
Closes #12

I managed to forget Docker only runs on Linux environments -> `mps` will never be available in it. However, the changes still allow selecting MPS when running `ia` _outside_ container mode, so it should be worth keeping.