### PR TITLE
use `objects` on each subclass, rather than creating a shim.

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run Pylint (source files)
         if: always()
-        run: >
+        run: |
           pylint --rcfile ./backend/pyproject.toml \
             backend/adumbra/gunicorn_config.py \
             backend/adumbra/ia \

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,5 +49,12 @@ jobs:
 
       - name: Run Pylint (source files)
         if: always()
-        run: pylint --rcfile ./backend/pyproject.toml backend/adumbra/gunicorn_config.py backend/adumbra/ia  backend/adumbra/tests backend/adumbra/workers backend/requirements-ia backend/update_requirements.py
-
+        run: >
+          pylint --rcfile ./backend/pyproject.toml \
+            backend/adumbra/gunicorn_config.py \
+            backend/adumbra/ia \
+            backend/adumbra/tests \
+            backend/adumbra/webserver \
+            backend/adumbra/workers \
+            backend/requirements-ia \
+            backend/update_requirements.py

--- a/backend/adumbra/database/annotations.py
+++ b/backend/adumbra/database/annotations.py
@@ -5,15 +5,15 @@ import cv2
 import imantics as im
 import numpy as np
 from flask_login import current_user
-from mongoengine import fields
+from mongoengine import fields, DynamicDocument, QuerySet
 
 from adumbra.database.categories import CategoryModel
 from adumbra.database.datasets import DatasetModel
 from adumbra.database.events import Event
-from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 
-class AnnotationModel(ShimmedDynamicDocument):
+class AnnotationModel(DynamicDocument):
+    objects: QuerySet
 
     COCO_PROPERTIES = [
         "id",

--- a/backend/adumbra/database/annotations.py
+++ b/backend/adumbra/database/annotations.py
@@ -5,7 +5,7 @@ import cv2
 import imantics as im
 import numpy as np
 from flask_login import current_user
-from mongoengine import fields, DynamicDocument, QuerySet
+from mongoengine import DynamicDocument, QuerySet, fields
 
 from adumbra.database.categories import CategoryModel
 from adumbra.database.datasets import DatasetModel

--- a/backend/adumbra/database/categories.py
+++ b/backend/adumbra/database/categories.py
@@ -1,11 +1,10 @@
 import imantics as im
 from flask_login import current_user
-from mongoengine import fields
-
-from adumbra.database.mongo_shim import ShimmedDynamicDocument
+from mongoengine import fields, DynamicDocument, QuerySet
 
 
-class CategoryModel(ShimmedDynamicDocument):
+class CategoryModel(DynamicDocument):
+    objects: QuerySet
 
     COCO_PROPERTIES = [
         "id",

--- a/backend/adumbra/database/categories.py
+++ b/backend/adumbra/database/categories.py
@@ -1,6 +1,6 @@
 import imantics as im
 from flask_login import current_user
-from mongoengine import fields, DynamicDocument, QuerySet
+from mongoengine import DynamicDocument, QuerySet, fields
 
 
 class CategoryModel(DynamicDocument):

--- a/backend/adumbra/database/datasets.py
+++ b/backend/adumbra/database/datasets.py
@@ -1,14 +1,14 @@
 import os
 
 from flask_login import current_user
-from mongoengine import fields
+from mongoengine import fields, DynamicDocument, QuerySet
 
 from adumbra.config import CONFIG
-from adumbra.database.mongo_shim import ShimmedDynamicDocument
 from adumbra.database.tasks import TaskModel
 
 
-class DatasetModel(ShimmedDynamicDocument):
+class DatasetModel(DynamicDocument):
+    objects: QuerySet
 
     id = fields.SequenceField(primary_key=True)
     name = fields.StringField(required=True, unique=True)

--- a/backend/adumbra/database/datasets.py
+++ b/backend/adumbra/database/datasets.py
@@ -1,7 +1,7 @@
 import os
 
 from flask_login import current_user
-from mongoengine import fields, DynamicDocument, QuerySet
+from mongoengine import DynamicDocument, QuerySet, fields
 
 from adumbra.config import CONFIG
 from adumbra.database.tasks import TaskModel

--- a/backend/adumbra/database/exports.py
+++ b/backend/adumbra/database/exports.py
@@ -1,11 +1,10 @@
 import datetime
 
-from mongoengine import fields
-
-from adumbra.database.mongo_shim import ShimmedDynamicDocument
+from mongoengine import fields, DynamicDocument, QuerySet
 
 
-class ExportModel(ShimmedDynamicDocument):
+class ExportModel(DynamicDocument):
+    objects: QuerySet
 
     id = fields.SequenceField(primary_key=True)
     dataset_id = fields.IntField(required=True)

--- a/backend/adumbra/database/exports.py
+++ b/backend/adumbra/database/exports.py
@@ -1,6 +1,6 @@
 import datetime
 
-from mongoengine import fields, DynamicDocument, QuerySet
+from mongoengine import DynamicDocument, QuerySet, fields
 
 
 class ExportModel(DynamicDocument):

--- a/backend/adumbra/database/images.py
+++ b/backend/adumbra/database/images.py
@@ -1,7 +1,7 @@
 import os
 
 import imantics as im
-from mongoengine import fields, DynamicDocument, QuerySet
+from mongoengine import DynamicDocument, QuerySet, fields
 from PIL import Image, ImageFile
 
 from adumbra.database.annotations import AnnotationModel

--- a/backend/adumbra/database/images.py
+++ b/backend/adumbra/database/images.py
@@ -1,18 +1,18 @@
 import os
 
 import imantics as im
-from mongoengine import fields
+from mongoengine import fields, DynamicDocument, QuerySet
 from PIL import Image, ImageFile
 
 from adumbra.database.annotations import AnnotationModel
 from adumbra.database.datasets import DatasetModel
 from adumbra.database.events import Event, SessionEvent
-from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
-class ImageModel(ShimmedDynamicDocument):
+class ImageModel(DynamicDocument):
+    objects: QuerySet
 
     COCO_PROPERTIES = [
         "id",

--- a/backend/adumbra/database/mongo_shim.py
+++ b/backend/adumbra/database/mongo_shim.py
@@ -1,8 +1,0 @@
-from mongoengine import DynamicDocument, QuerySet
-
-
-class ShimmedDynamicDocument(DynamicDocument):
-    """Provides type hinting on `objects`, nothing more."""
-
-    meta = {"abstract": True}
-    objects: QuerySet

--- a/backend/adumbra/database/tasks.py
+++ b/backend/adumbra/database/tasks.py
@@ -1,7 +1,7 @@
 import datetime
 import typing as t
 
-from mongoengine import fields, DynamicDocument, QuerySet
+from mongoengine import DynamicDocument, QuerySet, fields
 
 
 class TaskModel(DynamicDocument):

--- a/backend/adumbra/database/tasks.py
+++ b/backend/adumbra/database/tasks.py
@@ -1,12 +1,12 @@
 import datetime
 import typing as t
 
-from mongoengine import fields
-
-from adumbra.database.mongo_shim import ShimmedDynamicDocument
+from mongoengine import fields, DynamicDocument, QuerySet
 
 
-class TaskModel(ShimmedDynamicDocument):
+class TaskModel(DynamicDocument):
+    objects: QuerySet
+
     id = fields.SequenceField(primary_key=True)
 
     # Type of task: Importer, Exporter, Scanner, etc.

--- a/backend/adumbra/database/users.py
+++ b/backend/adumbra/database/users.py
@@ -1,16 +1,16 @@
 import datetime
 
 from flask_login import UserMixin
-from mongoengine import Q, fields
+from mongoengine import Q, fields, DynamicDocument, QuerySet
 
 from adumbra.database.annotations import AnnotationModel
 from adumbra.database.categories import CategoryModel
 from adumbra.database.datasets import DatasetModel
 from adumbra.database.images import ImageModel
-from adumbra.database.mongo_shim import ShimmedDynamicDocument
 
 
-class UserModel(ShimmedDynamicDocument, UserMixin):
+class UserModel(DynamicDocument, UserMixin):
+    objects: QuerySet
 
     password = fields.StringField(required=True)
     username = fields.StringField(max_length=25, required=True, unique=True)

--- a/backend/adumbra/database/users.py
+++ b/backend/adumbra/database/users.py
@@ -1,7 +1,7 @@
 import datetime
 
 from flask_login import UserMixin
-from mongoengine import Q, fields, DynamicDocument, QuerySet
+from mongoengine import DynamicDocument, Q, QuerySet, fields
 
 from adumbra.database.annotations import AnnotationModel
 from adumbra.database.categories import CategoryModel

--- a/backend/requirements-dev-pinned.txt
+++ b/backend/requirements-dev-pinned.txt
@@ -10,7 +10,7 @@ aniso8601==9.0.1
     # via flask-restx
 annotated-types==0.7.0
     # via pydantic
-astroid==3.3.7
+astroid==3.3.8
     # via pylint
 attrs==24.3.0
     # via
@@ -36,7 +36,7 @@ certifi==2024.12.14
     #   selenium
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
@@ -96,7 +96,7 @@ gunicorn==23.0.0
     # via adumbra (pyproject.toml)
 h11==0.14.0
     # via wsproto
-identify==2.6.3
+identify==2.6.4
     # via pre-commit
 idna==3.10
     # via
@@ -104,7 +104,7 @@ idna==3.10
     #   trio
 imantics @ git+https://github.com/SixK/imantics.git
     # via adumbra (pyproject.toml)
-importlib-resources==6.4.5
+importlib-resources==6.5.2
     # via flask-restx
 iniconfig==2.0.0
     # via pytest
@@ -120,7 +120,7 @@ jsonschema==4.23.0
     # via flask-restx
 jsonschema-specifications==2024.10.1
     # via jsonschema
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
 kombu==5.4.2
     # via celery
@@ -169,7 +169,7 @@ pathspec==0.12.1
     # via
     #   black
     #   unimport
-pillow==11.0.0
+pillow==11.1.0
     # via
     #   adumbra (pyproject.toml)
     #   matplotlib
@@ -198,11 +198,11 @@ pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
     # via adumbra (pyproject.toml)
-pylint==3.3.2
+pylint==3.3.3
     # via adumbra (pyproject.toml)
 pymongo==4.10.1
     # via mongoengine
-pyparsing==3.2.0
+pyparsing==3.2.1
     # via matplotlib
 pyproject-hooks==1.2.0
     # via
@@ -218,9 +218,9 @@ python-dateutil==2.9.0.post0
     #   matplotlib
 python-dotenv==1.0.1
     # via pydantic-settings
-python-engineio==4.11.1
+python-engineio==4.11.2
     # via python-socketio
-python-socketio==5.12.0
+python-socketio==5.12.1
     # via flask-socketio
 pytz==2024.2
     # via flask-restx
@@ -256,7 +256,7 @@ toml==0.10.2
     # via unimport
 tomlkit==0.13.2
     # via pylint
-trio==0.27.0
+trio==0.28.0
     # via
     #   selenium
     #   trio-websocket
@@ -286,7 +286,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.28.0
+virtualenv==20.28.1
     # via pre-commit
 watchdog==6.0.0
     # via adumbra (pyproject.toml)

--- a/backend/requirements-pinned.txt
+++ b/backend/requirements-pinned.txt
@@ -28,7 +28,7 @@ certifi==2024.12.14
     # via
     #   requests
     #   selenium
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
@@ -86,7 +86,7 @@ idna==3.10
     #   trio
 imantics @ git+https://github.com/SixK/imantics.git
     # via adumbra (pyproject.toml)
-importlib-resources==6.4.5
+importlib-resources==6.5.2
     # via flask-restx
 iniconfig==2.0.0
     # via pytest
@@ -98,7 +98,7 @@ jsonschema==4.23.0
     # via flask-restx
 jsonschema-specifications==2024.10.1
     # via jsonschema
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
 kombu==5.4.2
     # via celery
@@ -131,7 +131,7 @@ packaging==24.2
     #   gunicorn
     #   matplotlib
     #   pytest
-pillow==11.0.0
+pillow==11.1.0
     # via
     #   adumbra (pyproject.toml)
     #   matplotlib
@@ -151,7 +151,7 @@ pydantic-settings==2.7.1
     # via adumbra (pyproject.toml)
 pymongo==4.10.1
     # via mongoengine
-pyparsing==3.2.0
+pyparsing==3.2.1
     # via matplotlib
 pysocks==1.7.1
     # via urllib3
@@ -163,9 +163,9 @@ python-dateutil==2.9.0.post0
     #   matplotlib
 python-dotenv==1.0.1
     # via pydantic-settings
-python-engineio==4.11.1
+python-engineio==4.11.2
     # via python-socketio
-python-socketio==5.12.0
+python-socketio==5.12.1
     # via flask-socketio
 pytz==2024.2
     # via flask-restx
@@ -191,7 +191,7 @@ sniffio==1.3.1
     # via trio
 sortedcontainers==2.4.0
     # via trio
-trio==0.27.0
+trio==0.28.0
     # via
     #   selenium
     #   trio-websocket


### PR DESCRIPTION
Avoids unnecessary attempts to connect to mongodb by pylint