### PR TITLE
Better IA log & device handling

### DIFF
--- a/backend/adumbra/config/config.py
+++ b/backend/adumbra/config/config.py
@@ -75,9 +75,9 @@ class IASettings(BaseSettings):
 class Config(BaseSettings):
     model_config = SettingsConfigDict(env_nested_delimiter="__")
 
-    version: str = version_info.get_tag()
-
     name: str = "Adumbra"
+    version: str = version_info.get_tag()
+    log_level: str = "DEBUG"
 
     ### File Watcher
     file_watcher: bool = False

--- a/backend/adumbra/ia/__init__.py
+++ b/backend/adumbra/ia/__init__.py
@@ -6,10 +6,14 @@ from adumbra.config import CONFIG
 from adumbra.database import create_from_json
 from adumbra.ia.api import app
 
-gunicorn_logger = logging.getLogger("gunicorn.error")
 fastapi_logger = logging.getLogger("fastapi")
-fastapi_logger.handlers = gunicorn_logger.handlers
-fastapi_logger.setLevel(gunicorn_logger.level)
+module_logger = logging.getLogger("adumbra.ia")
+
+for logger in [fastapi_logger, module_logger]:
+    logger.setLevel(CONFIG.log_level)
+    if not logger.handlers:
+        logger.addHandler(logging.StreamHandler())
+
 
 origins = [
     "http://ia:6001",

--- a/backend/adumbra/ia/api.py
+++ b/backend/adumbra/ia/api.py
@@ -24,8 +24,7 @@ Model_T = t.TypeVar("Model_T", bound=BaseModel)
 AsForm = t.Annotated[Model_T, Form(media_type="multipart/form-data")]
 AsQuery = t.Annotated[Model_T, Query()]
 
-
-logger = logging.getLogger("gunicorn.error")
+logger = logging.getLogger(__name__)
 connect_mongo("ia")
 AssistantDBModel.ensure_defaults_available()
 
@@ -46,7 +45,6 @@ async def get_assistants(request: AsQuery[GetAssistantsRequest]):
     """
     if request is None:
         request = GetAssistantsRequest()
-    print(f"{request=}")
     kwargs = {}
     if request.assistant_name:
         kwargs["name"] = request.assistant_name
@@ -119,7 +117,6 @@ async def zim_segmentation(
     """
     Perform segmentation with a ZIM model.
     """
-    print(request.foreground_xy)
     if request.assistant_name == "zim":
         # Use default config
         config = ZIMConfig()

--- a/backend/adumbra/ia/util/segmentation_helpers.py
+++ b/backend/adumbra/ia/util/segmentation_helpers.py
@@ -13,7 +13,7 @@ from adumbra.ia.util.zim import ZIM
 from adumbra.types.assistants import SAM2Config, SegmentationResult, ZIMConfig
 
 BaseModel_co = t.TypeVar("BaseModel_co", bound=BaseModel, covariant=True)
-logger = logging.getLogger("gunicorn.error")
+logger = logging.getLogger(__name__)
 config_adapter = TypeAdapter[SAM2Config | ZIMConfig](SAM2Config | ZIMConfig)
 P = ParamSpec("P")
 R = t.TypeVar("R")

--- a/backend/adumbra/ia/util/zim.py
+++ b/backend/adumbra/ia/util/zim.py
@@ -8,7 +8,7 @@ from adumbra.config import CONFIG
 from adumbra.ia.util import update_none_values
 from adumbra.types import ZIMConfig
 
-logger = logging.getLogger("gunicorn.error")
+logger = logging.getLogger(__name__)
 
 
 class ZIM:

--- a/backend/adumbra/ia/util/zim.py
+++ b/backend/adumbra/ia/util/zim.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import numpy as np
+import torch
 from zim_anything import ZimPredictor, build_zim_model
 
 from adumbra.config import CONFIG
@@ -29,7 +30,11 @@ class ZIM:
 
         self.zim_model = build_zim_model(
             **config.model_dump(exclude={"assistant_type"})
-        ).to(device)
+        )
+        if ia_settings.is_gpu_like():
+            self.zim_model.cuda(torch.device(device))
+        elif ia_settings.is_cpu_like() and device == "mps":
+            logger.warning("ZIM doesn't support MPS acceleration, using CPU instead.")
         self.config = config
         self.is_loaded = True
         logger.info(f"ZIM model is loaded on device {device}.")

--- a/backend/adumbra/ia/util/zim.py
+++ b/backend/adumbra/ia/util/zim.py
@@ -35,6 +35,7 @@ class ZIM:
             self.zim_model.cuda(torch.device(device))
         elif ia_settings.is_cpu_like() and device == "mps":
             logger.warning("ZIM doesn't support MPS acceleration, using CPU instead.")
+            device = "cpu"
         self.config = config
         self.is_loaded = True
         logger.info(f"ZIM model is loaded on device {device}.")


### PR DESCRIPTION
- Use loggers per module instead of piggybacking on gunicorn (which isn't even used by fastapi, explaining why some log messages were lost as reported in #40)
- Provide config setting to reduce the number of logs if desired (currently only used by IA, but we can do the same config in other modules later)
- register stderr printout handlers to these loggers
- Fixes #40